### PR TITLE
タイマー精度の向上

### DIFF
--- a/OriginalTimer.js
+++ b/OriginalTimer.js
@@ -201,6 +201,9 @@
 
   var prevMsec = 0;
 
+  function getCurrentMsec(){
+    return SceneManager._currentTime || Date.now();
+  }
 
   //=============================================================================
   // Game_Interpreter_pluginCommand
@@ -242,7 +245,7 @@
         }
         RunFlag = true;
         if (TimerSave == 'YES') $gameTimer._fftfanttOriginalTimer_Run = true;
-        prevMsec = 1000 * Graphics.frameCount / 60;
+        prevMsec = getCurrentMsec();
         TimerRun();
         OriginalTimer = setInterval(TimerRun,CountUnit);
       }
@@ -485,8 +488,11 @@
       clearInterval(OriginalTimer);
       return;
     }
-    var now = 1000 * Graphics.frameCount / 60;
-    Count = Count + Math.max(0, (now - prevMsec) / 10);
+    var now = getCurrentMsec();
+    // NB: SceneManager.updateMain と同じ判定である事
+    var fTime = (now - prevMsec) / 1000;
+    if (fTime > 0.25) fTime = 0.25;
+    Count = Count + Math.max(0, fTime * 100);
     prevMsec = now;
     if (TimerType == 'アップ' || TimerType.toUpperCase() == 'UP'){
       CountTime = Math.round(Count);
@@ -690,7 +696,7 @@
     Count = $gameTimer._fftfanttOriginalTimer_Count
     if (!RunFlag) return;
     clearInterval(OriginalTimer);
-    prevMsec = 1000 * Graphics.frameCount / 60;
+    prevMsec = getCurrentMsec();
     OriginalTimer = setInterval(TimerRun,CountUnit);
   };
   

--- a/OriginalTimer.js
+++ b/OriginalTimer.js
@@ -491,7 +491,7 @@
     if (TimerType == 'アップ' || TimerType.toUpperCase() == 'UP'){
       CountTime = Math.round(Count);
     }else{
-      CountTime = TimerLimit - Count;
+      CountTime = TimerLimit - Math.round(Count);
     }
     day = parseInt(Math.floor(CountTime / 8640000),10);
     hr = parseInt((CountTime % 8640000) / 360000,10);

--- a/OriginalTimer.js
+++ b/OriginalTimer.js
@@ -242,7 +242,7 @@
         }
         RunFlag = true;
         if (TimerSave == 'YES') $gameTimer._fftfanttOriginalTimer_Run = true;
-        prevMsec = Date.now();
+        prevMsec = 1000 * Graphics.frameCount / 60;
         TimerRun();
         OriginalTimer = setInterval(TimerRun,CountUnit);
       }
@@ -485,7 +485,7 @@
       clearInterval(OriginalTimer);
       return;
     }
-    var now = Date.now();
+    var now = 1000 * Graphics.frameCount / 60;
     Count = Count + Math.max(0, (now - prevMsec) / 10);
     prevMsec = now;
     if (TimerType == 'アップ' || TimerType.toUpperCase() == 'UP'){
@@ -690,7 +690,7 @@
     Count = $gameTimer._fftfanttOriginalTimer_Count
     if (!RunFlag) return;
     clearInterval(OriginalTimer);
-    prevMsec = Date.now();
+    prevMsec = 1000 * Graphics.frameCount / 60;
     OriginalTimer = setInterval(TimerRun,CountUnit);
   };
   

--- a/OriginalTimer.js
+++ b/OriginalTimer.js
@@ -199,6 +199,8 @@
   var SwitchState = '';
   var SwitchNumber = 0;
 
+  var prevMsec = 0;
+
 
   //=============================================================================
   // Game_Interpreter_pluginCommand
@@ -240,7 +242,7 @@
         }
         RunFlag = true;
         if (TimerSave == 'YES') $gameTimer._fftfanttOriginalTimer_Run = true;
-        Count = Count - CountUnit / 10;
+        prevMsec = Date.now();
         TimerRun();
         OriginalTimer = setInterval(TimerRun,CountUnit);
       }
@@ -483,9 +485,11 @@
       clearInterval(OriginalTimer);
       return;
     }
-    Count = Count + CountUnit / 10;
+    var now = Date.now();
+    Count = Count + Math.max(0, (now - prevMsec) / 10);
+    prevMsec = now;
     if (TimerType == 'アップ' || TimerType.toUpperCase() == 'UP'){
-      CountTime = Count;
+      CountTime = Math.round(Count);
     }else{
       CountTime = TimerLimit - Count;
     }
@@ -686,6 +690,7 @@
     Count = $gameTimer._fftfanttOriginalTimer_Count
     if (!RunFlag) return;
     clearInterval(OriginalTimer);
+    prevMsec = Date.now();
     OriginalTimer = setInterval(TimerRun,CountUnit);
   };
   


### PR DESCRIPTION
こんにちは。
環境によってはオリジナルタイマープラグインが不正確になる問題があったので直してみました。

`setInterval()` や `setTimeout()` のタイマー実行は正確にならないので、実行毎に経過時間を加減算するようにしました。
この経過時間は `Date.now()` から取るか迷ったのですが、 `Date.now()` だとPCの時計いじりでこわれてしまうので、考えた結果 `Graphics.frameCount` から取るようにしました。
これはMV内の「プレイ時間」( `$gameSystem.playtime()` )と連動しているのでゲームがバックグラウンドになっている時に停止したり処理落ちしている時に遅くなりますが、ゲーム本体も停止したり遅くなっている筈でそれに同期しているので基本的には問題ないと思います(用途にもよりますが…)。

よろしければ、どうかよろしくお願いします。

追記：後で確認したところ、 `$gameSystem.playtime()` も正確ではない(ver1.1.0での「モニターのリフレッシュレートによって、ゲームの動作スピードが変動してしまう不具合を修正」の対応の際にプレイ時間だけ修正が漏れていた？)ようなので、 `SceneManager.updateMain()` と同様の判定になるように追加修正を行いました。